### PR TITLE
Support for Unfuddle accounts with forced SSL

### DIFF
--- a/lib/provider/unfuddle.rb
+++ b/lib/provider/unfuddle.rb
@@ -18,6 +18,7 @@ module TicketMaster::Provider
       if auth.account.nil? or auth.username.nil? or auth.password.nil?
         raise "Please provide at least an account (subdomain), username and password)"
       end
+      UnfuddleAPI.protocol = auth.protocol if auth.protocol?
       UnfuddleAPI.account = auth.account || auth.subdomain
       UnfuddleAPI.authenticate(auth.username, auth.password)
     end

--- a/spec/ticketmaster-unfuddle_spec.rb
+++ b/spec/ticketmaster-unfuddle_spec.rb
@@ -8,4 +8,9 @@ describe "Ticketmaster::Provider::Unfuddle" do
     @ticketmaster.should be_a_kind_of(TicketMaster::Provider::Unfuddle)
   end
 
+  it "should allow to use SSL" do
+    @ticketmaster = TicketMaster.new(:unfuddle, {:account => 'ticketmaster', :username => 'foo', :password => '000000', :protocol => 'https'})
+    @ticketmaster.provider::TICKET_API.site.should be_an_instance_of(URI::HTTPS)
+    @ticketmaster.provider::PROJECT_API.site.should be_an_instance_of(URI::HTTPS)
+  end
 end


### PR DESCRIPTION
Hello!
We happen to use Unfuddle with "force ssl" option which disallow using API with http:

> > unfuddle = TicketMaster.new(:unfuddle, {:account => 'evrone', :username => '..', :password => '..'})
> > unfuddle.projects
> > ActiveResource::ForbiddenAccess: Failed with 403 Forbidden

So I've added :protocol option (and a spec for it):

> > unfuddle = TicketMaster.new(:unfuddle, {:account => 'evrone', :username => '..', :password => '..', :protocol => 'https'})
> > unfuddle.projects
> > => [<#TicketMaster::Provider::Unfuddle::Project account_id=1 ...
